### PR TITLE
[FEATURE] Remove hidden column from exclude list

### DIFF
--- a/Configuration/TCA/tx_koningcomments_domain_model_comment.php
+++ b/Configuration/TCA/tx_koningcomments_domain_model_comment.php
@@ -29,7 +29,7 @@ return call_user_func(function ($extension, $table) {
         'palettes' => [],
         'columns' => [
             'hidden' => [
-                'exclude' => true,
+                'exclude' => false,
                 'label' => 'LLL:EXT:lang/locallang_general.xlf:LGL.hidden',
                 'config' => [
                     'type' => 'check',


### PR DESCRIPTION
The hidden column was the only column in the exclude list. Either make all columns excludable, or none at all.