### PR TITLE
[FEATURE] Set default sorting to date descending

### DIFF
--- a/Configuration/TCA/tx_koningcomments_domain_model_comment.php
+++ b/Configuration/TCA/tx_koningcomments_domain_model_comment.php
@@ -19,6 +19,7 @@ return call_user_func(function ($extension, $table) {
             'typeicon_classes' => [
                 'default' => 'tcarecords-tx_koningcomments_domain_model_comment-default',
             ],
+            'default_sortby' => 'date DESC',
         ],
         'interface' => [
             'showRecordFieldList' => 'hidden, date, url, body, user, reply_to, replies',


### PR DESCRIPTION
Logically the super users will want to modify the most recent comments, so it makes sense to order the comments list by descending date.